### PR TITLE
Build container image and use it in setup

### DIFF
--- a/files/10-ipv6.conf
+++ b/files/10-ipv6.conf
@@ -1,0 +1,1 @@
+net.ipv6.conf.all.disable_ipv6 = 0

--- a/files/kni.service
+++ b/files/kni.service
@@ -2,3 +2,5 @@
 Restart=always
 ExecStart=
 ExecStart=/usr/bin/network-runtime
+[Install]
+WantedBy=multi-user.target

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,48 @@
+# Copyright 2018 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# kind node base image
+#
+# For systemd + docker configuration used below, see the following references:
+# https://systemd.io/CONTAINER_INTERFACE/
+
+# start from debian slim, this image is reasonably small as a starting point
+# for a kubernetes node image, it doesn't contain much (anything?) we don't need
+# this stage will install basic files and packages
+ARG BASE_IMAGE=kindest/node@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+FROM $BASE_IMAGE as base
+# overwrite
+ADD ./bin/containerd /usr/local/bin/containerd
+ADD ./bin/network-runtime /usr/bin/network-runtime
+ADD ./bin/kubelet /usr/bin/kubelet
+ADD ./bin/bridge /opt/cni/bin/bridge
+ADD ./bin/host-local /opt/cni/bin/host-local
+ADD ./files/kni.service /etc/systemd/system/kni.service
+ADD ./files/config.toml /etc/containerd/config.toml
+ADD ./files/10-ipv6.conf /etc/sysctl.d/10-ipv6.conf
+RUN systemctl enable kni.service
+
+# squash down to one compressed layer, without any lingering whiteout files etc
+FROM base
+COPY --from=base / /
+# add metadata, must be done after the squashing
+# first tell systemd that it is in docker (it will check for the container env)
+# https://systemd.io/CONTAINER_INTERFACE/
+ENV container docker
+# systemd exits on SIGRTMIN+3, not SIGTERM (which re-executes it)
+# https://bugzilla.redhat.com/show_bug.cgi?id=1201657
+STOPSIGNAL SIGRTMIN+3
+
+# NOTE: this is *only* for documentation, the entrypoint is overridden later
+ENTRYPOINT [ "/usr/local/bin/entrypoint", "/sbin/init" ]

--- a/kind.yaml
+++ b/kind.yaml
@@ -7,4 +7,6 @@ networking:
 
 nodes:
  - role: control-plane
+   image: gchr.io/mikezappa87/kni-demo:latest
  - role: worker
+   image: gchr.io/mikezappa87/kni-demo:latest

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -22,3 +22,6 @@ popd
 pushd plugins
 CGO_ENABLED=0 ./build_linux.sh && cp ./bin/bridge ${BINDIR} && cp ./bin/host-local ${BINDIR}
 popd
+
+popd
+docker build -t gchr.io/mikezappa87/kni-demo:latest -f images/Dockerfile .

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -5,42 +5,12 @@ set -o pipefail
 kind delete cluster --name test1 || true
 
 kind create cluster --config kind.yaml --name test1
-
 kubectl cluster-info --context kind-test1
 
-kubectl scale --replicas=0 -n kube-system deployment coredns
-kubectl scale --replicas=0 -n local-path-storage deployment local-path-provisioner
-kubectl -n kube-system wait --for=delete -l k8s-app=kube-dns pod --timeout=5m
-kubectl -n local-path-storage wait --for=delete -l app=local-path-provisioner pod --timeout=5m
-
-for node in test1-control-plane test1-worker; do
-	docker cp ./bin/containerd ${node}:/usr/local/bin/containerd
-	docker cp ./bin/network-runtime ${node}:/usr/bin/network-runtime
-	docker cp ./bin/kubelet ${node}:/usr/bin/kubelet
-	docker cp ./files/kni.service ${node}:/etc/systemd/system/kni.service
-	docker cp ./files/config.toml ${node}:/etc/containerd/config.toml
-	docker cp ./bin/bridge ${node}:/opt/cni/bin/bridge
-	docker cp ./bin/host-local ${node}:/opt/cni/bin/host-local
-
-	docker exec ${node} systemctl daemon-reload
-	docker exec ${node} systemctl start kni
-	docker exec ${node} systemctl restart kubelet
-	docker exec ${node} systemctl restart containerd
-	docker exec ${node} sysctl -w net.ipv6.conf.all.disable_ipv6=0
-done
-
-# wait for kubelet again...
-sleep 10
-
-kubectl scale --replicas=2 -n kube-system deployment coredns
-kubectl scale --replicas=1 -n local-path-storage deployment local-path-provisioner
-
 kubectl taint node test1-control-plane node-role.kubernetes.io/control-plane:NoSchedule-
-
 # wait for all k8s resources
 sleep 10
-kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=5m
-
 kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
+kubectl wait --for=condition=Ready pods --all --all-namespaces --timeout=5m
 
 kubectl get pods -A


### PR DESCRIPTION
This change creates container image at build phase and use it in kind. This simplifies setup script by omit replace contianerd/kubelet on-the-fly.

This image tag is expected to use pre-built at further CI build in github action workflows.